### PR TITLE
Pull Request: simplify the API for create store

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "name": "vscode-jest-tests",
+      "request": "launch",
+      "args": [
+        "--runInBand"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+    }
+  ]
+}

--- a/API.md
+++ b/API.md
@@ -74,9 +74,9 @@ The same as the higher-order-component above, but as a component: `<Subscribe to
 import { Provider } from 'react-contextual'
 ```
 
-A small Redux-like store. Declare the initial state with the `initialState` prop, and actions with the `actions` prop. The provider will distribute `{ ...state, actions }` to listening components which either use React's API directly or contextual's `subscribe` hoc to consume it. Alternatively you can pass an [external store](https://github.com/drcmda/react-contextual/blob/master/API.md#createstore) by the `store` props.
+A small Redux-like store. Declare props that represents the state and actions on the state. The provider will distribute the state and actions as props to listening components which either use React's API directly or contextual's `subscribe` hoc to consume it. Alternatively you can pass an [external store](https://github.com/drcmda/react-contextual/blob/master/API.md#createstore) by the `store` props.
 
-Actions are made of a collection of functions which return an object that is going to be merged back into the state using regular `setState` semantics.
+The actions on the state are basically functions which return an object that is going to be merged back into the state using regular `setState` semantics.
 
 They can be simple ...
 
@@ -105,20 +105,16 @@ setColor: backgroundColor => async state => {
 import { createStore } from 'react-contextual'
 
 const externalStore = createStore({
-    initialState: { count: 1 },
-    actions: { up: () => state => ({ count: state.count + 1 }) },
-    // Everything you add on top will be available to components that subscribe to it:
-    personalStuff: {
-        something: 123
-    }
+    count: 1,
+    up: () => state => ({ count: state.count + 1 })
 })
 ```
 
-Creates an external store. It takes an object that needs to provide `initialState` and `actions`. The store is fully reactive, that means you can read out state (`store.getState()`) and call actions (`store.actions.up()`) as well as `store.subscribe(callback)` to it whenever it changes. If you do not pass actions, it will create `actions.setState` with React's semantics by default. Note: the store will only be alive once it has been tied to a provider, it won't function on its own.
+Creates an external store. It takes an object that needs to specify some state and actions on the state. The store is fully reactive, that means you can read out state (`store.getState()`) and call actions (`store.getState().up()`) as well as `store.subscribe(callback)` to it whenever it changes. If you do not specify any actions in the object passed to `createStore`, a default action `setState` will be created with React's semantics by default. Note: the store will only be alive once it has been tied to a provider, it won't function on its own.
 
 ```jsx
 const remove = externalStore.subscribe(state => console.log(state))
-externalStore.actions.up()
+externalStore.getState().up()
 const count = externalStore.getState().count
 remove()
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Click [this link](https://github.com/drcmda/react-contextual/blob/master/PITFALL
 
 <b>Examples</b>: [Counter](https://codesandbox.io/embed/3vo9164z25) | [Global setState](https://codesandbox.io/embed/01l8z634qn) | [Async actions](https://codesandbox.io/embed/lxly45lvkl) | [Memoization/Reselect](https://codesandbox.io/embed/yvx9my007z) | [Multiple stores](https://codesandbox.io/embed/0o8pj1jz7v) | [External store](https://codesandbox.io/embed/jzwv46729y)
 
-Use [Provider](https://github.com/drcmda/react-contextual/blob/master/API.md#provider) to distribute state and actions. Connect components either by using a [HOC](https://github.com/drcmda/react-contextual/blob/master/API.md#subscribe) or [render-props](https://github.com/drcmda/react-contextual/blob/master/API.md#subscribe-as-a-component).
+Pass a `store` (which stores some state and actions to update the state) to [Provider](https://github.com/drcmda/react-contextual/blob/master/API.md#provider). Then receive the props in the store either by using a [HOC](https://github.com/drcmda/react-contextual/blob/master/API.md#subscribe) or [render-props](https://github.com/drcmda/react-contextual/blob/master/API.md#subscribe-as-a-component).
 
 #### Render props
 
@@ -21,11 +21,9 @@ Use [Provider](https://github.com/drcmda/react-contextual/blob/master/API.md#pro
 import { Provider, Subscribe } from 'react-contextual'
 
 const store = {
-    initialState: { count: 0 },
-    actions: {
-        up: () => state => ({ count: state.count + 1 }),
-        down: () => state => ({ count: state.count - 1 }),
-    },
+    count: 0,
+    up: () => state => ({ count: state.count + 1 }),
+    down: () => state => ({ count: state.count - 1 }),
 }
 
 const App = () => (
@@ -34,8 +32,8 @@ const App = () => (
             {props => (
                 <div>
                     <h1>{props.count}</h1>
-                    <button onClick={props.actions.up}>Up</button>
-                    <button onClick={props.actions.down}>Down</button>
+                    <button onClick={props.up}>Up</button>
+                    <button onClick={props.down}>Down</button>
                 </div>
             )}
         </Subscribe>
@@ -51,8 +49,8 @@ import { Provider, subscribe } from 'react-contextual'
 const View = subscribe()(props => (
     <div>
         <h1>{props.count}</h1>
-        <button onClick={props.actions.up}>Up</button>
-        <button onClick={props.actions.down}>Down</button>
+        <button onClick={props.up}>Up</button>
+        <button onClick={props.down}>Down</button>
     </div>
 ))
 
@@ -87,8 +85,8 @@ There are a few key differences:
 import { Provider, createStore, subscribe } from 'react-contextual'
 
 const externalStore = createStore({
-    initialState: { text: 'Hello' },
-    actions: { setText: text => ({ text }) }
+    text: 'Hello',
+    setText: text => ({ text })
 })
 
 const App = () => (
@@ -102,14 +100,14 @@ const App = () => (
 
 #### Global setState
 
-If you do not supply actions [createStore](https://github.com/drcmda/react-contextual/blob/master/API.md#createstore) will add setState by default. This applies to both createStore and the Provider above.
+If you do not supply any functions in the object passed to [createStore](https://github.com/drcmda/react-contextual/blob/master/API.md#createstore), a `setState` function would be added automatically for you. This applies to both `createStore` and the `Provider` above.
 
 ```jsx
-const store = createStore({ initialState: { count: 0 } })
+const store = createStore({ count: 0 })
 
 const Test = subscribe(store)(
     props => (
-        <button onClick={() => props.actions.setState(state => ({ count: state.count + 1 }))}>
+        <button onClick={() => props.setState(state => ({ count: state.count + 1 }))}>
             {props.count}
         </button>
     ),

--- a/tests/__snapshots__/store.js.snap
+++ b/tests/__snapshots__/store.js.snap
@@ -2,32 +2,19 @@
 
 exports[`async action 1`] = `
 <Provider
-  actions={
-    Object {
-      "async": [Function],
-      "functional": [Function],
-      "simple": [Function],
-    }
-  }
-  extra={100}
-  initialState={
-    Object {
-      "count": 0,
-    }
-  }
+  async={[Function]}
+  count={0}
+  functional={[Function]}
+  simple={[Function]}
 >
   <RenderPure>
     <SubscribeWrap>
       <Component
-        actions={
-          Object {
-            "async": [Function],
-            "functional": [Function],
-            "simple": [Function],
-          }
-        }
+        async={[Function]}
         count={0}
-        extra={100}
+        functional={[Function]}
+        setState={[Function]}
+        simple={[Function]}
       >
         <button
           onClick={[Function]}
@@ -42,32 +29,19 @@ exports[`async action 1`] = `
 
 exports[`async action 2`] = `
 <Provider
-  actions={
-    Object {
-      "async": [Function],
-      "functional": [Function],
-      "simple": [Function],
-    }
-  }
-  extra={100}
-  initialState={
-    Object {
-      "count": 0,
-    }
-  }
+  async={[Function]}
+  count={0}
+  functional={[Function]}
+  simple={[Function]}
 >
   <RenderPure>
     <SubscribeWrap>
       <Component
-        actions={
-          Object {
-            "async": [Function],
-            "functional": [Function],
-            "simple": [Function],
-          }
-        }
+        async={[Function]}
         count={1}
-        extra={100}
+        functional={[Function]}
+        setState={[Function]}
+        simple={[Function]}
       >
         <button
           onClick={[Function]}
@@ -82,32 +56,19 @@ exports[`async action 2`] = `
 
 exports[`await actions & access state 1`] = `
 <Provider
-  actions={
-    Object {
-      "async": [Function],
-      "functional": [Function],
-      "simple": [Function],
-    }
-  }
-  extra={100}
-  initialState={
-    Object {
-      "count": 0,
-    }
-  }
+  async={[Function]}
+  count={0}
+  functional={[Function]}
+  simple={[Function]}
 >
   <RenderPure>
     <SubscribeWrap>
       <_class2
-        actions={
-          Object {
-            "async": [Function],
-            "functional": [Function],
-            "simple": [Function],
-          }
-        }
+        async={[Function]}
         count={0}
-        extra={100}
+        functional={[Function]}
+        setState={[Function]}
+        simple={[Function]}
       >
         <div>
           0
@@ -123,32 +84,19 @@ exports[`await actions & access state 1`] = `
 
 exports[`await actions & access state 2`] = `
 <Provider
-  actions={
-    Object {
-      "async": [Function],
-      "functional": [Function],
-      "simple": [Function],
-    }
-  }
-  extra={100}
-  initialState={
-    Object {
-      "count": 0,
-    }
-  }
+  async={[Function]}
+  count={0}
+  functional={[Function]}
+  simple={[Function]}
 >
   <RenderPure>
     <SubscribeWrap>
       <_class2
-        actions={
-          Object {
-            "async": [Function],
-            "functional": [Function],
-            "simple": [Function],
-          }
-        }
+        async={[Function]}
         count={4}
-        extra={100}
+        functional={[Function]}
+        setState={[Function]}
+        simple={[Function]}
       >
         <div>
           4
@@ -166,11 +114,6 @@ exports[`external store 1`] = `
 <Provider
   store={
     Object {
-      "actions": Object {
-        "async": [Function],
-        "functional": [Function],
-        "simple": [Function],
-      },
       "context": Object {
         "$$typeof": Symbol(react.context),
         "Consumer": [Circular],
@@ -187,14 +130,12 @@ exports[`external store 1`] = `
       "destroy": [Function],
       "getState": [Function],
       "id": "externalTest",
-      "initialState": Object {
-        "count": 0,
-      },
-      "props": Object {
-        "extra": 100,
-      },
       "state": Object {
+        "async": [Function],
         "count": 0,
+        "functional": [Function],
+        "setState": [Function],
+        "simple": [Function],
       },
       "subscribe": [Function],
       "subscriptions": Set {},
@@ -204,7 +145,11 @@ exports[`external store 1`] = `
   <RenderPure>
     <SubscribeWrap>
       <Component
+        async={[Function]}
         count={0}
+        functional={[Function]}
+        setState={[Function]}
+        simple={[Function]}
       >
         <button
           onClick={[Function]}
@@ -221,11 +166,6 @@ exports[`external store 2`] = `
 <Provider
   store={
     Object {
-      "actions": Object {
-        "async": [Function],
-        "functional": [Function],
-        "simple": [Function],
-      },
       "context": Object {
         "$$typeof": Symbol(react.context),
         "Consumer": [Circular],
@@ -242,14 +182,12 @@ exports[`external store 2`] = `
       "destroy": [Function],
       "getState": [Function],
       "id": "externalTest",
-      "initialState": Object {
-        "count": 0,
-      },
-      "props": Object {
-        "extra": 100,
-      },
       "state": Object {
+        "async": [Function],
         "count": 2,
+        "functional": [Function],
+        "setState": [Function],
+        "simple": [Function],
       },
       "subscribe": [Function],
       "subscriptions": Set {},
@@ -259,7 +197,11 @@ exports[`external store 2`] = `
   <RenderPure>
     <SubscribeWrap>
       <Component
+        async={[Function]}
         count={2}
+        functional={[Function]}
+        setState={[Function]}
+        simple={[Function]}
       >
         <button
           onClick={[Function]}
@@ -276,9 +218,6 @@ exports[`external store, setState 1`] = `
 <Provider
   store={
     Object {
-      "actions": Object {
-        "setState": [Function],
-      },
       "context": Object {
         "$$typeof": Symbol(react.context),
         "Consumer": [Circular],
@@ -295,12 +234,9 @@ exports[`external store, setState 1`] = `
       "destroy": [Function],
       "getState": [Function],
       "id": "externalTest2",
-      "initialState": Object {
-        "count": 0,
-      },
-      "props": Object {},
       "state": Object {
         "count": 0,
+        "setState": [Function],
       },
       "subscribe": [Function],
       "subscriptions": Set {},
@@ -310,12 +246,8 @@ exports[`external store, setState 1`] = `
   <RenderPure>
     <SubscribeWrap>
       <Component
-        actions={
-          Object {
-            "setState": [Function],
-          }
-        }
         count={0}
+        setState={[Function]}
       >
         <button
           onClick={[Function]}
@@ -332,9 +264,6 @@ exports[`external store, setState 2`] = `
 <Provider
   store={
     Object {
-      "actions": Object {
-        "setState": [Function],
-      },
       "context": Object {
         "$$typeof": Symbol(react.context),
         "Consumer": [Circular],
@@ -351,12 +280,9 @@ exports[`external store, setState 2`] = `
       "destroy": [Function],
       "getState": [Function],
       "id": "externalTest2",
-      "initialState": Object {
-        "count": 0,
-      },
-      "props": Object {},
       "state": Object {
         "count": 1,
+        "setState": [Function],
       },
       "subscribe": [Function],
       "subscriptions": Set {},
@@ -366,12 +292,8 @@ exports[`external store, setState 2`] = `
   <RenderPure>
     <SubscribeWrap>
       <Component
-        actions={
-          Object {
-            "setState": [Function],
-          }
-        }
         count={1}
+        setState={[Function]}
       >
         <button
           onClick={[Function]}
@@ -384,120 +306,21 @@ exports[`external store, setState 2`] = `
 </Provider>
 `;
 
-exports[`extras 1`] = `
-<Provider
-  actions={
-    Object {
-      "async": [Function],
-      "functional": [Function],
-      "simple": [Function],
-    }
-  }
-  extra={100}
-  initialState={
-    Object {
-      "count": 0,
-    }
-  }
->
-  <RenderPure>
-    <Provider
-      store={
-        Object {
-          "actions": Object {
-            "setState": [Function],
-          },
-          "context": Object {
-            "$$typeof": Symbol(react.context),
-            "Consumer": [Circular],
-            "Provider": Object {
-              "$$typeof": Symbol(react.provider),
-              "_context": [Circular],
-            },
-            "_calculateChangedBits": null,
-            "_changedBits": 0,
-            "_currentRenderer": Object {},
-            "_currentValue": undefined,
-            "_defaultValue": undefined,
-          },
-          "destroy": [Function],
-          "getState": [Function],
-          "id": "externalTest3",
-          "initialState": Object {
-            "count": 5,
-          },
-          "props": Object {
-            "extra": 1000,
-          },
-          "state": Object {
-            "count": 5,
-          },
-          "subscribe": [Function],
-          "subscriptions": Set {},
-        }
-      }
-    >
-      <RenderPure>
-        <SubscribeWrap>
-          <Component
-            a={
-              Object {
-                "actions": Object {
-                  "async": [Function],
-                  "functional": [Function],
-                  "simple": [Function],
-                },
-                "count": 0,
-                "extra": 100,
-              }
-            }
-            b={
-              Object {
-                "actions": Object {
-                  "setState": [Function],
-                },
-                "count": 5,
-                "extra": 1000,
-              }
-            }
-          >
-            1105
-          </Component>
-        </SubscribeWrap>
-      </RenderPure>
-    </Provider>
-  </RenderPure>
-</Provider>
-`;
-
 exports[`functional action 1`] = `
 <Provider
-  actions={
-    Object {
-      "async": [Function],
-      "functional": [Function],
-      "simple": [Function],
-    }
-  }
-  extra={100}
-  initialState={
-    Object {
-      "count": 0,
-    }
-  }
+  async={[Function]}
+  count={0}
+  functional={[Function]}
+  simple={[Function]}
 >
   <RenderPure>
     <SubscribeWrap>
       <Component
-        actions={
-          Object {
-            "async": [Function],
-            "functional": [Function],
-            "simple": [Function],
-          }
-        }
+        async={[Function]}
         count={0}
-        extra={100}
+        functional={[Function]}
+        setState={[Function]}
+        simple={[Function]}
       >
         <button
           onClick={[Function]}
@@ -512,32 +335,19 @@ exports[`functional action 1`] = `
 
 exports[`functional action 2`] = `
 <Provider
-  actions={
-    Object {
-      "async": [Function],
-      "functional": [Function],
-      "simple": [Function],
-    }
-  }
-  extra={100}
-  initialState={
-    Object {
-      "count": 0,
-    }
-  }
+  async={[Function]}
+  count={0}
+  functional={[Function]}
+  simple={[Function]}
 >
   <RenderPure>
     <SubscribeWrap>
       <Component
-        actions={
-          Object {
-            "async": [Function],
-            "functional": [Function],
-            "simple": [Function],
-          }
-        }
+        async={[Function]}
         count={1}
-        extra={100}
+        functional={[Function]}
+        setState={[Function]}
+        simple={[Function]}
       >
         <button
           onClick={[Function]}
@@ -552,44 +362,15 @@ exports[`functional action 2`] = `
 
 exports[`mount/unmount 1`] = `<App />`;
 
-exports[`no actions 1`] = `
-<Provider
-  actions={null}
-  initialState={
-    Object {
-      "count": 0,
-    }
-  }
->
-  <RenderPure>
-    <SubscribeWrap>
-      <Component
-        count={0}
-      >
-        0
-      </Component>
-    </SubscribeWrap>
-  </RenderPure>
-</Provider>
-`;
-
 exports[`no actions, setState 1`] = `
 <Provider
-  initialState={
-    Object {
-      "count": 0,
-    }
-  }
+  count={0}
 >
   <RenderPure>
     <SubscribeWrap>
       <Component
-        actions={
-          Object {
-            "setState": [Function],
-          }
-        }
         count={0}
+        setState={[Function]}
       >
         <button
           onClick={[Function]}
@@ -604,21 +385,13 @@ exports[`no actions, setState 1`] = `
 
 exports[`no actions, setState 2`] = `
 <Provider
-  initialState={
-    Object {
-      "count": 0,
-    }
-  }
+  count={0}
 >
   <RenderPure>
     <SubscribeWrap>
       <Component
-        actions={
-          Object {
-            "setState": [Function],
-          }
-        }
         count={1}
+        setState={[Function]}
       >
         <button
           onClick={[Function]}
@@ -633,21 +406,13 @@ exports[`no actions, setState 2`] = `
 
 exports[`renders properly 1`] = `
 <Provider
-  initialState={
-    Object {
-      "count": 0,
-    }
-  }
+  count={0}
 >
   <RenderPure>
     <SubscribeWrap>
       <Component
-        actions={
-          Object {
-            "setState": [Function],
-          }
-        }
         count={0}
+        setState={[Function]}
       >
         0
       </Component>
@@ -658,32 +423,19 @@ exports[`renders properly 1`] = `
 
 exports[`simple action 1`] = `
 <Provider
-  actions={
-    Object {
-      "async": [Function],
-      "functional": [Function],
-      "simple": [Function],
-    }
-  }
-  extra={100}
-  initialState={
-    Object {
-      "count": 0,
-    }
-  }
+  async={[Function]}
+  count={0}
+  functional={[Function]}
+  simple={[Function]}
 >
   <RenderPure>
     <SubscribeWrap>
       <Component
-        actions={
-          Object {
-            "async": [Function],
-            "functional": [Function],
-            "simple": [Function],
-          }
-        }
+        async={[Function]}
         count={0}
-        extra={100}
+        functional={[Function]}
+        setState={[Function]}
+        simple={[Function]}
       >
         <button
           onClick={[Function]}
@@ -698,32 +450,19 @@ exports[`simple action 1`] = `
 
 exports[`simple action 2`] = `
 <Provider
-  actions={
-    Object {
-      "async": [Function],
-      "functional": [Function],
-      "simple": [Function],
-    }
-  }
-  extra={100}
-  initialState={
-    Object {
-      "count": 0,
-    }
-  }
+  async={[Function]}
+  count={0}
+  functional={[Function]}
+  simple={[Function]}
 >
   <RenderPure>
     <SubscribeWrap>
       <Component
-        actions={
-          Object {
-            "async": [Function],
-            "functional": [Function],
-            "simple": [Function],
-          }
-        }
+        async={[Function]}
         count={1}
-        extra={100}
+        functional={[Function]}
+        setState={[Function]}
+        simple={[Function]}
       >
         <button
           onClick={[Function]}

--- a/tests/__snapshots__/subscribe.js.snap
+++ b/tests/__snapshots__/subscribe.js.snap
@@ -3,11 +3,7 @@
 exports[`subscribe("key") 1`] = `
 <Provider
   id="key"
-  initialState={
-    Object {
-      "message": "success!",
-    }
-  }
+  message="success!"
 >
   <RenderPure>
     <SubscribeWrap
@@ -15,21 +11,15 @@ exports[`subscribe("key") 1`] = `
     >
       <Component
         id="key"
-        state={
-          Object {
-            "actions": Object {
-              "setState": [Function],
-            },
-            "message": "success!",
-          }
-        }
+        message="success!"
+        setState={[Function]}
       >
         success!
       </Component>
     </SubscribeWrap>
     <Subscribe
       id="key"
-      select="state"
+      select={[Function]}
       to="key"
     >
       <SubscribeWrap
@@ -37,14 +27,8 @@ exports[`subscribe("key") 1`] = `
       >
         <Component
           id="key"
-          state={
-            Object {
-              "actions": Object {
-                "setState": [Function],
-              },
-              "message": "success!",
-            }
-          }
+          message="success!"
+          setState={[Function]}
         >
           success!
         </Component>
@@ -57,11 +41,7 @@ exports[`subscribe("key") 1`] = `
 exports[`subscribe("key", "state") 1`] = `
 <Provider
   id="key"
-  initialState={
-    Object {
-      "message": "success!",
-    }
-  }
+  message="success!"
 >
   <RenderPure>
     <SubscribeWrap
@@ -71,10 +51,8 @@ exports[`subscribe("key", "state") 1`] = `
         id="key"
         state={
           Object {
-            "actions": Object {
-              "setState": [Function],
-            },
             "message": "success!",
+            "setState": [Function],
           }
         }
       >
@@ -93,10 +71,8 @@ exports[`subscribe("key", "state") 1`] = `
           id="key"
           state={
             Object {
-              "actions": Object {
-                "setState": [Function],
-              },
               "message": "success!",
+              "setState": [Function],
             }
           }
         >
@@ -111,24 +87,16 @@ exports[`subscribe("key", "state") 1`] = `
 exports[`subscribe("key", store => store) 1`] = `
 <Provider
   id="key"
-  initialState={
-    Object {
-      "message": "success!",
-    }
-  }
+  message="success!"
 >
   <RenderPure>
     <SubscribeWrap
       id="key"
     >
       <Component
-        actions={
-          Object {
-            "setState": [Function],
-          }
-        }
         id="key"
         message="success!"
+        setState={[Function]}
       >
         success!
       </Component>
@@ -142,13 +110,9 @@ exports[`subscribe("key", store => store) 1`] = `
         id="key"
       >
         <Component
-          actions={
-            Object {
-              "setState": [Function],
-            }
-          }
           id="key"
           message="success!"
+          setState={[Function]}
         >
           success!
         </Component>
@@ -160,21 +124,15 @@ exports[`subscribe("key", store => store) 1`] = `
 
 exports[`subscribe("state") 1`] = `
 <Provider
-  initialState={
-    Object {
-      "message": "success!",
-    }
-  }
+  message="success!"
 >
   <RenderPure>
     <SubscribeWrap>
       <Component
         state={
           Object {
-            "actions": Object {
-              "setState": [Function],
-            },
             "message": "success!",
+            "setState": [Function],
           }
         }
       >
@@ -203,10 +161,8 @@ exports[`subscribe("state") 1`] = `
         <Component
           state={
             Object {
-              "actions": Object {
-                "setState": [Function],
-              },
               "message": "success!",
+              "setState": [Function],
             }
           }
         >
@@ -220,21 +176,13 @@ exports[`subscribe("state") 1`] = `
 
 exports[`subscribe() 1`] = `
 <Provider
-  initialState={
-    Object {
-      "message": "success!",
-    }
-  }
+  message="success!"
 >
   <RenderPure>
     <SubscribeWrap>
       <Component
-        actions={
-          Object {
-            "setState": [Function],
-          }
-        }
         message="success!"
+        setState={[Function]}
       >
         success!
       </Component>
@@ -259,12 +207,8 @@ exports[`subscribe() 1`] = `
     >
       <SubscribeWrap>
         <Component
-          actions={
-            Object {
-              "setState": [Function],
-            }
-          }
           message="success!"
+          setState={[Function]}
         >
           success!
         </Component>
@@ -276,49 +220,31 @@ exports[`subscribe() 1`] = `
 
 exports[`subscribe([a,b], (a,b) => props) 1`] = `
 <Provider
-  actions={
-    Object {
-      "up": [Function],
-    }
-  }
+  count={0}
   id="id1"
-  initialState={
-    Object {
-      "count": 0,
-    }
-  }
+  up={[Function]}
 >
   <RenderPure>
     <Provider
-      actions={
-        Object {
-          "up": [Function],
-        }
-      }
+      count={0}
       id="id2"
-      initialState={
-        Object {
-          "count": 0,
-        }
-      }
+      up={[Function]}
     >
       <RenderPure>
         <SubscribeWrap>
           <Component
             store1={
               Object {
-                "actions": Object {
-                  "up": [Function],
-                },
                 "count": 0,
+                "setState": [Function],
+                "up": [Function],
               }
             }
             store2={
               Object {
-                "actions": Object {
-                  "up": [Function],
-                },
                 "count": 0,
+                "setState": [Function],
+                "up": [Function],
               }
             }
           >
@@ -344,18 +270,16 @@ exports[`subscribe([a,b], (a,b) => props) 1`] = `
             <Component
               store1={
                 Object {
-                  "actions": Object {
-                    "up": [Function],
-                  },
                   "count": 0,
+                  "setState": [Function],
+                  "up": [Function],
                 }
               }
               store2={
                 Object {
-                  "actions": Object {
-                    "up": [Function],
-                  },
                   "count": 0,
+                  "setState": [Function],
+                  "up": [Function],
                 }
               }
             >
@@ -371,49 +295,31 @@ exports[`subscribe([a,b], (a,b) => props) 1`] = `
 
 exports[`subscribe([a,b], (a,b) => props) 2`] = `
 <Provider
-  actions={
-    Object {
-      "up": [Function],
-    }
-  }
+  count={0}
   id="id1"
-  initialState={
-    Object {
-      "count": 0,
-    }
-  }
+  up={[Function]}
 >
   <RenderPure>
     <Provider
-      actions={
-        Object {
-          "up": [Function],
-        }
-      }
+      count={0}
       id="id2"
-      initialState={
-        Object {
-          "count": 0,
-        }
-      }
+      up={[Function]}
     >
       <RenderPure>
         <SubscribeWrap>
           <Component
             store1={
               Object {
-                "actions": Object {
-                  "up": [Function],
-                },
                 "count": 1,
+                "setState": [Function],
+                "up": [Function],
               }
             }
             store2={
               Object {
-                "actions": Object {
-                  "up": [Function],
-                },
                 "count": 1,
+                "setState": [Function],
+                "up": [Function],
               }
             }
           >
@@ -439,18 +345,16 @@ exports[`subscribe([a,b], (a,b) => props) 2`] = `
             <Component
               store1={
                 Object {
-                  "actions": Object {
-                    "up": [Function],
-                  },
                   "count": 1,
+                  "setState": [Function],
+                  "up": [Function],
                 }
               }
               store2={
                 Object {
-                  "actions": Object {
-                    "up": [Function],
-                  },
                   "count": 1,
+                  "setState": [Function],
+                  "up": [Function],
                 }
               }
             >
@@ -466,49 +370,31 @@ exports[`subscribe([a,b], (a,b) => props) 2`] = `
 
 exports[`subscribe([a,b], [a,b]) 1`] = `
 <Provider
-  actions={
-    Object {
-      "up": [Function],
-    }
-  }
+  count={0}
   id="id1"
-  initialState={
-    Object {
-      "count": 0,
-    }
-  }
+  up={[Function]}
 >
   <RenderPure>
     <Provider
-      actions={
-        Object {
-          "up": [Function],
-        }
-      }
+      count={0}
       id="id2"
-      initialState={
-        Object {
-          "count": 0,
-        }
-      }
+      up={[Function]}
     >
       <RenderPure>
         <SubscribeWrap>
           <Component
             store1={
               Object {
-                "actions": Object {
-                  "up": [Function],
-                },
                 "count": 0,
+                "setState": [Function],
+                "up": [Function],
               }
             }
             store2={
               Object {
-                "actions": Object {
-                  "up": [Function],
-                },
                 "count": 0,
+                "setState": [Function],
+                "up": [Function],
               }
             }
           >
@@ -539,18 +425,16 @@ exports[`subscribe([a,b], [a,b]) 1`] = `
             <Component
               store1={
                 Object {
-                  "actions": Object {
-                    "up": [Function],
-                  },
                   "count": 0,
+                  "setState": [Function],
+                  "up": [Function],
                 }
               }
               store2={
                 Object {
-                  "actions": Object {
-                    "up": [Function],
-                  },
                   "count": 0,
+                  "setState": [Function],
+                  "up": [Function],
                 }
               }
             >
@@ -566,49 +450,31 @@ exports[`subscribe([a,b], [a,b]) 1`] = `
 
 exports[`subscribe([a,b], [a,b]) 2`] = `
 <Provider
-  actions={
-    Object {
-      "up": [Function],
-    }
-  }
+  count={0}
   id="id1"
-  initialState={
-    Object {
-      "count": 0,
-    }
-  }
+  up={[Function]}
 >
   <RenderPure>
     <Provider
-      actions={
-        Object {
-          "up": [Function],
-        }
-      }
+      count={0}
       id="id2"
-      initialState={
-        Object {
-          "count": 0,
-        }
-      }
+      up={[Function]}
     >
       <RenderPure>
         <SubscribeWrap>
           <Component
             store1={
               Object {
-                "actions": Object {
-                  "up": [Function],
-                },
                 "count": 1,
+                "setState": [Function],
+                "up": [Function],
               }
             }
             store2={
               Object {
-                "actions": Object {
-                  "up": [Function],
-                },
                 "count": 1,
+                "setState": [Function],
+                "up": [Function],
               }
             }
           >
@@ -639,18 +505,16 @@ exports[`subscribe([a,b], [a,b]) 2`] = `
             <Component
               store1={
                 Object {
-                  "actions": Object {
-                    "up": [Function],
-                  },
                   "count": 1,
+                  "setState": [Function],
+                  "up": [Function],
                 }
               }
               store2={
                 Object {
-                  "actions": Object {
-                    "up": [Function],
-                  },
                   "count": 1,
+                  "setState": [Function],
+                  "up": [Function],
                 }
               }
             >
@@ -842,21 +706,13 @@ exports[`subscribe(AnyContextSingleValue) 1`] = `
 
 exports[`subscribe(ProviderContext) 1`] = `
 <Provider
-  initialState={
-    Object {
-      "message": "success!",
-    }
-  }
+  message="success!"
 >
   <RenderPure>
     <SubscribeWrap>
       <Component
-        actions={
-          Object {
-            "setState": [Function],
-          }
-        }
         message="success!"
+        setState={[Function]}
       >
         success!
       </Component>
@@ -881,12 +737,8 @@ exports[`subscribe(ProviderContext) 1`] = `
     >
       <SubscribeWrap>
         <Component
-          actions={
-            Object {
-              "setState": [Function],
-            }
-          }
           message="success!"
+          setState={[Function]}
         >
           success!
         </Component>
@@ -898,21 +750,15 @@ exports[`subscribe(ProviderContext) 1`] = `
 
 exports[`subscribe(ProviderContext, "state") 1`] = `
 <Provider
-  initialState={
-    Object {
-      "message": "success!",
-    }
-  }
+  message="success!"
 >
   <RenderPure>
     <SubscribeWrap>
       <Component
         state={
           Object {
-            "actions": Object {
-              "setState": [Function],
-            },
             "message": "success!",
+            "setState": [Function],
           }
         }
       >
@@ -941,10 +787,8 @@ exports[`subscribe(ProviderContext, "state") 1`] = `
         <Component
           state={
             Object {
-              "actions": Object {
-                "setState": [Function],
-              },
               "message": "success!",
+              "setState": [Function],
             }
           }
         >
@@ -958,21 +802,13 @@ exports[`subscribe(ProviderContext, "state") 1`] = `
 
 exports[`subscribe(ProviderContext, context => context) 1`] = `
 <Provider
-  initialState={
-    Object {
-      "message": "success!",
-    }
-  }
+  message="success!"
 >
   <RenderPure>
     <SubscribeWrap>
       <Component
-        actions={
-          Object {
-            "setState": [Function],
-          }
-        }
         message="success!"
+        setState={[Function]}
       >
         success!
       </Component>
@@ -997,12 +833,8 @@ exports[`subscribe(ProviderContext, context => context) 1`] = `
     >
       <SubscribeWrap>
         <Component
-          actions={
-            Object {
-              "setState": [Function],
-            }
-          }
           message="success!"
+          setState={[Function]}
         >
           success!
         </Component>
@@ -1014,21 +846,13 @@ exports[`subscribe(ProviderContext, context => context) 1`] = `
 
 exports[`subscribe(store => store) 1`] = `
 <Provider
-  initialState={
-    Object {
-      "message": "success!",
-    }
-  }
+  message="success!"
 >
   <RenderPure>
     <SubscribeWrap>
       <Component
-        actions={
-          Object {
-            "setState": [Function],
-          }
-        }
         message="success!"
+        setState={[Function]}
       >
         success!
       </Component>
@@ -1053,12 +877,8 @@ exports[`subscribe(store => store) 1`] = `
     >
       <SubscribeWrap>
         <Component
-          actions={
-            Object {
-              "setState": [Function],
-            }
-          }
           message="success!"
+          setState={[Function]}
         >
           success!
         </Component>
@@ -1070,16 +890,8 @@ exports[`subscribe(store => store) 1`] = `
 
 exports[`subscribe(store) 1`] = `
 <Provider
-  initialState={
-    Object {
-      "message": "success!",
-    }
-  }
   store={
     Object {
-      "actions": Object {
-        "setState": [Function],
-      },
       "context": Object {
         "$$typeof": Symbol(react.context),
         "Consumer": [Circular],
@@ -1096,12 +908,9 @@ exports[`subscribe(store) 1`] = `
       "destroy": [Function],
       "getState": [Function],
       "id": "testStore",
-      "initialState": Object {
-        "message": "success!",
-      },
-      "props": Object {},
       "state": Object {
         "message": "success!",
+        "setState": [Function],
       },
       "subscribe": [Function],
       "subscriptions": Set {},
@@ -1111,12 +920,8 @@ exports[`subscribe(store) 1`] = `
   <RenderPure>
     <SubscribeWrap>
       <Component
-        actions={
-          Object {
-            "setState": [Function],
-          }
-        }
         message="success!"
+        setState={[Function]}
       >
         success!
       </Component>
@@ -1125,9 +930,6 @@ exports[`subscribe(store) 1`] = `
       select={[Function]}
       to={
         Object {
-          "actions": Object {
-            "setState": [Function],
-          },
           "context": Object {
             "$$typeof": Symbol(react.context),
             "Consumer": [Circular],
@@ -1144,12 +946,9 @@ exports[`subscribe(store) 1`] = `
           "destroy": [Function],
           "getState": [Function],
           "id": "testStore",
-          "initialState": Object {
-            "message": "success!",
-          },
-          "props": Object {},
           "state": Object {
             "message": "success!",
+            "setState": [Function],
           },
           "subscribe": [Function],
           "subscriptions": Set {},
@@ -1158,12 +957,8 @@ exports[`subscribe(store) 1`] = `
     >
       <SubscribeWrap>
         <Component
-          actions={
-            Object {
-              "setState": [Function],
-            }
-          }
           message="success!"
+          setState={[Function]}
         >
           success!
         </Component>
@@ -1175,16 +970,8 @@ exports[`subscribe(store) 1`] = `
 
 exports[`subscribe(store, "state") 1`] = `
 <Provider
-  initialState={
-    Object {
-      "message": "success!",
-    }
-  }
   store={
     Object {
-      "actions": Object {
-        "setState": [Function],
-      },
       "context": Object {
         "$$typeof": Symbol(react.context),
         "Consumer": [Circular],
@@ -1201,12 +988,9 @@ exports[`subscribe(store, "state") 1`] = `
       "destroy": [Function],
       "getState": [Function],
       "id": "testStore",
-      "initialState": Object {
-        "message": "success!",
-      },
-      "props": Object {},
       "state": Object {
         "message": "success!",
+        "setState": [Function],
       },
       "subscribe": [Function],
       "subscriptions": Set {},
@@ -1218,10 +1002,8 @@ exports[`subscribe(store, "state") 1`] = `
       <Component
         state={
           Object {
-            "actions": Object {
-              "setState": [Function],
-            },
             "message": "success!",
+            "setState": [Function],
           }
         }
       >
@@ -1232,9 +1014,6 @@ exports[`subscribe(store, "state") 1`] = `
       select="state"
       to={
         Object {
-          "actions": Object {
-            "setState": [Function],
-          },
           "context": Object {
             "$$typeof": Symbol(react.context),
             "Consumer": [Circular],
@@ -1251,12 +1030,9 @@ exports[`subscribe(store, "state") 1`] = `
           "destroy": [Function],
           "getState": [Function],
           "id": "testStore",
-          "initialState": Object {
-            "message": "success!",
-          },
-          "props": Object {},
           "state": Object {
             "message": "success!",
+            "setState": [Function],
           },
           "subscribe": [Function],
           "subscriptions": Set {},
@@ -1267,10 +1043,8 @@ exports[`subscribe(store, "state") 1`] = `
         <Component
           state={
             Object {
-              "actions": Object {
-                "setState": [Function],
-              },
               "message": "success!",
+              "setState": [Function],
             }
           }
         >
@@ -1284,16 +1058,8 @@ exports[`subscribe(store, "state") 1`] = `
 
 exports[`subscribe(store, context => context) 1`] = `
 <Provider
-  initialState={
-    Object {
-      "message": "success!",
-    }
-  }
   store={
     Object {
-      "actions": Object {
-        "setState": [Function],
-      },
       "context": Object {
         "$$typeof": Symbol(react.context),
         "Consumer": [Circular],
@@ -1310,12 +1076,9 @@ exports[`subscribe(store, context => context) 1`] = `
       "destroy": [Function],
       "getState": [Function],
       "id": "testStore",
-      "initialState": Object {
-        "message": "success!",
-      },
-      "props": Object {},
       "state": Object {
         "message": "success!",
+        "setState": [Function],
       },
       "subscribe": [Function],
       "subscriptions": Set {},
@@ -1325,12 +1088,8 @@ exports[`subscribe(store, context => context) 1`] = `
   <RenderPure>
     <SubscribeWrap>
       <Component
-        actions={
-          Object {
-            "setState": [Function],
-          }
-        }
         message="success!"
+        setState={[Function]}
       >
         success!
       </Component>
@@ -1339,9 +1098,6 @@ exports[`subscribe(store, context => context) 1`] = `
       select={[Function]}
       to={
         Object {
-          "actions": Object {
-            "setState": [Function],
-          },
           "context": Object {
             "$$typeof": Symbol(react.context),
             "Consumer": [Circular],
@@ -1358,12 +1114,9 @@ exports[`subscribe(store, context => context) 1`] = `
           "destroy": [Function],
           "getState": [Function],
           "id": "testStore",
-          "initialState": Object {
-            "message": "success!",
-          },
-          "props": Object {},
           "state": Object {
             "message": "success!",
+            "setState": [Function],
           },
           "subscribe": [Function],
           "subscriptions": Set {},
@@ -1372,12 +1125,8 @@ exports[`subscribe(store, context => context) 1`] = `
     >
       <SubscribeWrap>
         <Component
-          actions={
-            Object {
-              "setState": [Function],
-            }
-          }
           message="success!"
+          setState={[Function]}
         >
           success!
         </Component>


### PR DESCRIPTION
 I would like to propose the following API.

To use the built-in ProviderContext

```javascrpt
const store = {
    count: 0,
    up: () => state => ({ count: state.count + 1 }),
    down: () => state => ({ count: state.count - 1 }),
}

const App = () => (
    <Provider {...store}>
        <Subscribe>
            {props => (
                <div>
                    <h1>{props.count}</h1>
                    <button onClick={props.up}>Up</button>
                    <button onClick={props.down}>Down</button>
                </div>
            )}
        </Subscribe>
    </Provider>
)
```

To use external store

```javascript
const externalStore = createStore({
    text: 'Hello',
    setText: text => ({ text })
})

const App = () => (
    <Provider store={store}>
        <Subscribe to={store}>
            {props => <div>{props.text}</div>}
        </Subscribe>
    </Provider>
)
```

Compared with the current API, there are two changes:
(1) we don't need to specify "initialState" and "action" anymore.
(2) we don't support the global functions in the store anymore.

Each store contains just one javascript object, which has some states and the functions to update those states. In this way, the store concept is similar to the container concept in the unstated.

Note:
- I updated the test cases accordingly. 
- I haven't updated the README.md. Some of the code examples in codesandbox.io in the readme needs to be updated as well.